### PR TITLE
remove workarounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ $(YQ_BINARY):
 	go build -o $@ github.com/mikefarah/yq/v4
 
 $(SPEAKEASY_BINARY):
-	cd $(@D) && curl https://github.com/speakeasy-api/speakeasy/releases/download/v1.116.0/speakeasy_$(OS)_$(ARCH).zip -L -o speakeasy.zip && unzip -o speakeasy.zip $(@F) && rm speakeasy.zip ; chmod +x $(@F)
+	cd $(@D) && curl https://github.com/speakeasy-api/speakeasy/releases/download/v1.118.3/speakeasy_$(OS)_$(ARCH).zip -L -o speakeasy.zip && unzip -o speakeasy.zip $(@F) && rm speakeasy.zip ; chmod +x $(@F)
 
 $(GOJSONTOYAML_BINARY):
 	go build -o $@ github.com/brancz/gojsontoyaml
@@ -128,10 +128,6 @@ saladcloud.yaml: saladcloud.json $(GOJSONTOYAML_BINARY) $(YQ_BINARY) patch.sh
 
 files.gen: saladcloud.yaml $(SPEAKEASY_BINARY)
 	$(SPEAKEASY_BINARY) generate sdk --lang terraform --schema $< --out .
-	# Workaround for https://github.com/speakeasy-api/speakeasy/issues/326
-	find . -type f -name '*' -not -path "./bin/*" | parallel chmod -x
-	sed -i '\|-0\.0|i //lint:ignore SA4026 this is generated code' internal/provider/reflect/number.go
-	sed -i '\|// key=value option|a //lint:ignore SA4011 this is generated code' internal/sdk/pkg/utils/utils.go
 	# Add tools.
 	sed -i '\|// Documentation generation|i _ "honnef.co/go/tools/cmd/staticcheck"' tools/tools.go
 	sed -i '\|// Documentation generation|i _ "github.com/mikefarah/yq/v4"' tools/tools.go

--- a/README.md
+++ b/README.md
@@ -83,11 +83,13 @@ provider "saladcloud" {
 
 ## SDK Example Usage
 <!-- Start SDK Example Usage -->
-## Testing the provider locally
+### Testing the provider locally
 
 Should you want to validate a change locally, the `--debug` flag allows you to execute the provider against a terraform instance locally.
 
 This also allows for debuggers (e.g. delve) to be attached to the provider.
+
+### Example
 
 ```sh
 go run main.go --debug

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,10 +1,4 @@
 <!-- Start SDK Example Usage -->
-## Testing the provider locally
-
-Should you want to validate a change locally, the `--debug` flag allows you to execute the provider against a terraform instance locally.
-
-This also allows for debuggers (e.g. delve) to be attached to the provider.
-
 ```sh
 go run main.go --debug
 # Copy the TF_REATTACH_PROVIDERS env var

--- a/gen.yaml
+++ b/gen.yaml
@@ -3,10 +3,12 @@ generation:
   comments: {}
   sdkClassName: SDK
   repoURL: https://github.com/squat/terraform-provider-saladcloud.git
+  usageSnippets:
+    optionalPropertyRendering: withExample
 features:
   terraform:
     constsAndDefaults: 0.1.1
-    core: 3.3.1
+    core: 3.4.2
     deprecations: 2.81.1
     globalSecurity: 2.81.1
     globalServerURLs: 2.82.0

--- a/internal/provider/containergroup_data_source.go
+++ b/internal/provider/containergroup_data_source.go
@@ -8,13 +8,10 @@ import (
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk"
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk/pkg/models/operations"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/squat/terraform-provider-saladcloud/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -141,9 +138,6 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 			},
 			"create_time": schema.StringAttribute{
 				Computed: true,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"current_state": schema.SingleNestedAttribute{
 				Computed: true,
@@ -153,9 +147,6 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 					},
 					"finish_time": schema.StringAttribute{
 						Computed: true,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"instance_status_count": schema.SingleNestedAttribute{
 						Computed: true,
@@ -174,22 +165,9 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 					},
 					"start_time": schema.StringAttribute{
 						Computed: true,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"status": schema.StringAttribute{
-						Computed: true,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"pending",
-								"running",
-								"stopped",
-								"succeeded",
-								"failed",
-								"deploying",
-							),
-						},
+						Computed:    true,
 						Description: `must be one of ["pending", "running", "stopped", "succeeded", "failed", "deploying"]`,
 					},
 				},
@@ -250,12 +228,7 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 								Computed: true,
 							},
 							"scheme": schema.StringAttribute{
-								Computed: true,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"http",
-									),
-								},
+								Computed:    true,
 								Description: `must be one of ["http"]`,
 							},
 						},
@@ -300,12 +273,7 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 						Computed: true,
 					},
 					"protocol": schema.StringAttribute{
-						Computed: true,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"http",
-							),
-						},
+						Computed:    true,
 						Description: `must be one of ["http"]`,
 					},
 				},
@@ -368,12 +336,7 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 								Computed: true,
 							},
 							"scheme": schema.StringAttribute{
-								Computed: true,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"http",
-									),
-								},
+								Computed:    true,
 								Description: `must be one of ["http"]`,
 							},
 						},
@@ -405,14 +368,7 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 				Computed: true,
 			},
 			"restart_policy": schema.StringAttribute{
-				Computed: true,
-				Validators: []validator.String{
-					stringvalidator.OneOf(
-						"always",
-						"on_failure",
-						"never",
-					),
-				},
+				Computed:    true,
 				Description: `must be one of ["always", "on_failure", "never"]`,
 			},
 			"startup_probe": schema.SingleNestedAttribute{
@@ -464,12 +420,7 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 								Computed: true,
 							},
 							"scheme": schema.StringAttribute{
-								Computed: true,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"http",
-									),
-								},
+								Computed:    true,
 								Description: `must be one of ["http"]`,
 							},
 						},
@@ -499,9 +450,6 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 			},
 			"update_time": schema.StringAttribute{
 				Computed: true,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}

--- a/internal/provider/containergroup_resource.go
+++ b/internal/provider/containergroup_resource.go
@@ -334,7 +334,8 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 						},
 					},
 					"status": schema.StringAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `must be one of ["pending", "running", "stopped", "succeeded", "failed", "deploying"]`,
 						Validators: []validator.String{
 							stringvalidator.OneOf(
 								"pending",
@@ -345,7 +346,6 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 								"deploying",
 							),
 						},
-						Description: `must be one of ["pending", "running", "stopped", "succeeded", "failed", "deploying"]`,
 					},
 				},
 				Description: `Represents a container group state`,
@@ -453,13 +453,13 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),
 								},
-								Optional: true,
+								Optional:    true,
+								Description: `must be one of ["http"]`,
 								Validators: []validator.String{
 									stringvalidator.OneOf(
 										"http",
 									),
 								},
-								Description: `must be one of ["http"]`,
 							},
 						},
 					},
@@ -534,13 +534,13 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplace(),
 						},
-						Required: true,
+						Required:    true,
+						Description: `must be one of ["http"]`,
 						Validators: []validator.String{
 							stringvalidator.OneOf(
 								"http",
 							),
 						},
-						Description: `must be one of ["http"]`,
 					},
 				},
 				Description: `Represents container group networking parameters`,
@@ -650,13 +650,13 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),
 								},
-								Optional: true,
+								Optional:    true,
+								Description: `must be one of ["http"]`,
 								Validators: []validator.String{
 									stringvalidator.OneOf(
 										"http",
 									),
 								},
-								Description: `must be one of ["http"]`,
 							},
 						},
 					},
@@ -709,7 +709,8 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-				Required: true,
+				Required:    true,
+				Description: `must be one of ["always", "on_failure", "never"]`,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"always",
@@ -717,7 +718,6 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 						"never",
 					),
 				},
-				Description: `must be one of ["always", "on_failure", "never"]`,
 			},
 			"startup_probe": schema.SingleNestedAttribute{
 				Computed: true,
@@ -816,13 +816,13 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),
 								},
-								Optional: true,
+								Optional:    true,
+								Description: `must be one of ["http"]`,
 								Validators: []validator.String{
 									stringvalidator.OneOf(
 										"http",
 									),
 								},
-								Description: `must be one of ["http"]`,
 							},
 						},
 					},

--- a/internal/provider/containergroupinstances_data_source.go
+++ b/internal/provider/containergroupinstances_data_source.go
@@ -8,13 +8,10 @@ import (
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk"
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk/pkg/models/operations"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/squat/terraform-provider-saladcloud/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -59,20 +56,11 @@ func (r *ContainerGroupInstancesDataSource) Schema(ctx context.Context, req data
 						},
 						"state": schema.StringAttribute{
 							Computed: true,
-							Validators: []validator.String{
-								stringvalidator.OneOf(
-									"creating",
-									"running",
-								),
-							},
 							MarkdownDescription: `must be one of ["creating", "running"]` + "\n" +
 								`The state of the container group instance`,
 						},
 						"update_time": schema.StringAttribute{
-							Computed: true,
-							Validators: []validator.String{
-								validators.IsRFC3339(),
-							},
+							Computed:    true,
 							Description: `The UTC date & time when the workload on this machine transitioned to the current state`,
 						},
 					},

--- a/internal/provider/containergroups_data_source.go
+++ b/internal/provider/containergroups_data_source.go
@@ -8,13 +8,10 @@ import (
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk"
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk/pkg/models/operations"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/squat/terraform-provider-saladcloud/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -132,9 +129,6 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 						},
 						"create_time": schema.StringAttribute{
 							Computed: true,
-							Validators: []validator.String{
-								validators.IsRFC3339(),
-							},
 						},
 						"current_state": schema.SingleNestedAttribute{
 							Computed: true,
@@ -144,9 +138,6 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 								},
 								"finish_time": schema.StringAttribute{
 									Computed: true,
-									Validators: []validator.String{
-										validators.IsRFC3339(),
-									},
 								},
 								"instance_status_count": schema.SingleNestedAttribute{
 									Computed: true,
@@ -165,22 +156,9 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 								},
 								"start_time": schema.StringAttribute{
 									Computed: true,
-									Validators: []validator.String{
-										validators.IsRFC3339(),
-									},
 								},
 								"status": schema.StringAttribute{
-									Computed: true,
-									Validators: []validator.String{
-										stringvalidator.OneOf(
-											"pending",
-											"running",
-											"stopped",
-											"succeeded",
-											"failed",
-											"deploying",
-										),
-									},
+									Computed:    true,
 									Description: `must be one of ["pending", "running", "stopped", "succeeded", "failed", "deploying"]`,
 								},
 							},
@@ -241,12 +219,7 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 											Computed: true,
 										},
 										"scheme": schema.StringAttribute{
-											Computed: true,
-											Validators: []validator.String{
-												stringvalidator.OneOf(
-													"http",
-												),
-											},
+											Computed:    true,
 											Description: `must be one of ["http"]`,
 										},
 									},
@@ -290,12 +263,7 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 									Computed: true,
 								},
 								"protocol": schema.StringAttribute{
-									Computed: true,
-									Validators: []validator.String{
-										stringvalidator.OneOf(
-											"http",
-										),
-									},
+									Computed:    true,
 									Description: `must be one of ["http"]`,
 								},
 							},
@@ -350,12 +318,7 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 											Computed: true,
 										},
 										"scheme": schema.StringAttribute{
-											Computed: true,
-											Validators: []validator.String{
-												stringvalidator.OneOf(
-													"http",
-												),
-											},
+											Computed:    true,
 											Description: `must be one of ["http"]`,
 										},
 									},
@@ -387,14 +350,7 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 							Computed: true,
 						},
 						"restart_policy": schema.StringAttribute{
-							Computed: true,
-							Validators: []validator.String{
-								stringvalidator.OneOf(
-									"always",
-									"on_failure",
-									"never",
-								),
-							},
+							Computed:    true,
 							Description: `must be one of ["always", "on_failure", "never"]`,
 						},
 						"startup_probe": schema.SingleNestedAttribute{
@@ -446,12 +402,7 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 											Computed: true,
 										},
 										"scheme": schema.StringAttribute{
-											Computed: true,
-											Validators: []validator.String{
-												stringvalidator.OneOf(
-													"http",
-												),
-											},
+											Computed:    true,
 											Description: `must be one of ["http"]`,
 										},
 									},
@@ -481,9 +432,6 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 						},
 						"update_time": schema.StringAttribute{
 							Computed: true,
-							Validators: []validator.String{
-								validators.IsRFC3339(),
-							},
 						},
 					},
 				},

--- a/internal/provider/quotas_data_source.go
+++ b/internal/provider/quotas_data_source.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/squat/terraform-provider-saladcloud/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -73,10 +71,7 @@ func (r *QuotasDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				},
 			},
 			"create_time": schema.StringAttribute{
-				Computed: true,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
+				Computed:    true,
 				Description: `The time the resource was created`,
 			},
 			"organization_name": schema.StringAttribute{
@@ -95,10 +90,7 @@ func (r *QuotasDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				},
 			},
 			"update_time": schema.StringAttribute{
-				Computed: true,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
+				Computed:    true,
 				Description: `The time the resource was last updated`,
 			},
 		},

--- a/internal/provider/recipe_data_source.go
+++ b/internal/provider/recipe_data_source.go
@@ -8,10 +8,8 @@ import (
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk"
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk/pkg/models/operations"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -71,12 +69,7 @@ func (r *RecipeDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 						Computed: true,
 					},
 					"protocol": schema.StringAttribute{
-						Computed: true,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"http",
-							),
-						},
+						Computed:    true,
 						Description: `must be one of ["http"]`,
 					},
 				},

--- a/internal/provider/recipedeployment_data_source.go
+++ b/internal/provider/recipedeployment_data_source.go
@@ -8,13 +8,10 @@ import (
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk"
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk/pkg/models/operations"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/squat/terraform-provider-saladcloud/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -62,9 +59,6 @@ func (r *RecipeDeploymentDataSource) Schema(ctx context.Context, req datasource.
 					},
 					"finish_time": schema.StringAttribute{
 						Computed: true,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"instance_status_count": schema.SingleNestedAttribute{
 						Computed: true,
@@ -83,22 +77,9 @@ func (r *RecipeDeploymentDataSource) Schema(ctx context.Context, req datasource.
 					},
 					"start_time": schema.StringAttribute{
 						Computed: true,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"status": schema.StringAttribute{
-						Computed: true,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"pending",
-								"running",
-								"stopped",
-								"succeeded",
-								"failed",
-								"deploying",
-							),
-						},
+						Computed:    true,
 						Description: `must be one of ["pending", "running", "stopped", "succeeded", "failed", "deploying"]`,
 					},
 				},
@@ -127,12 +108,7 @@ func (r *RecipeDeploymentDataSource) Schema(ctx context.Context, req datasource.
 						Computed: true,
 					},
 					"protocol": schema.StringAttribute{
-						Computed: true,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"http",
-							),
-						},
+						Computed:    true,
 						Description: `must be one of ["http"]`,
 					},
 				},
@@ -170,12 +146,7 @@ func (r *RecipeDeploymentDataSource) Schema(ctx context.Context, req datasource.
 								Computed: true,
 							},
 							"protocol": schema.StringAttribute{
-								Computed: true,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"http",
-									),
-								},
+								Computed:    true,
 								Description: `must be one of ["http"]`,
 							},
 						},

--- a/internal/provider/recipedeployment_resource.go
+++ b/internal/provider/recipedeployment_resource.go
@@ -92,7 +92,8 @@ func (r *RecipeDeploymentResource) Schema(ctx context.Context, req resource.Sche
 						},
 					},
 					"status": schema.StringAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `must be one of ["pending", "running", "stopped", "succeeded", "failed", "deploying"]`,
 						Validators: []validator.String{
 							stringvalidator.OneOf(
 								"pending",
@@ -103,7 +104,6 @@ func (r *RecipeDeploymentResource) Schema(ctx context.Context, req resource.Sche
 								"deploying",
 							),
 						},
-						Description: `must be one of ["pending", "running", "stopped", "succeeded", "failed", "deploying"]`,
 					},
 				},
 				Description: `Represents a container group state`,
@@ -143,13 +143,13 @@ func (r *RecipeDeploymentResource) Schema(ctx context.Context, req resource.Sche
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplace(),
 						},
-						Required: true,
+						Required:    true,
+						Description: `must be one of ["http"]`,
 						Validators: []validator.String{
 							stringvalidator.OneOf(
 								"http",
 							),
 						},
-						Description: `must be one of ["http"]`,
 					},
 				},
 				Description: `Represents recipe networking parameters`,
@@ -186,13 +186,13 @@ func (r *RecipeDeploymentResource) Schema(ctx context.Context, req resource.Sche
 								Computed: true,
 							},
 							"protocol": schema.StringAttribute{
-								Computed: true,
+								Computed:    true,
+								Description: `must be one of ["http"]`,
 								Validators: []validator.String{
 									stringvalidator.OneOf(
 										"http",
 									),
 								},
-								Description: `must be one of ["http"]`,
 							},
 						},
 						Description: `Represents recipe networking parameters`,

--- a/internal/provider/recipedeploymentinstances_data_source.go
+++ b/internal/provider/recipedeploymentinstances_data_source.go
@@ -8,13 +8,10 @@ import (
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk"
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk/pkg/models/operations"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/squat/terraform-provider-saladcloud/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -59,20 +56,11 @@ func (r *RecipeDeploymentInstancesDataSource) Schema(ctx context.Context, req da
 						},
 						"state": schema.StringAttribute{
 							Computed: true,
-							Validators: []validator.String{
-								stringvalidator.OneOf(
-									"creating",
-									"running",
-								),
-							},
 							MarkdownDescription: `must be one of ["creating", "running"]` + "\n" +
 								`The state of the recipe deployment instance`,
 						},
 						"update_time": schema.StringAttribute{
-							Computed: true,
-							Validators: []validator.String{
-								validators.IsRFC3339(),
-							},
+							Computed:    true,
 							Description: `The UTC date & time when the workload on this machine transitioned to the current state`,
 						},
 					},

--- a/internal/provider/recipedeployments_data_source.go
+++ b/internal/provider/recipedeployments_data_source.go
@@ -8,13 +8,10 @@ import (
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk"
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk/pkg/models/operations"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/squat/terraform-provider-saladcloud/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -60,9 +57,6 @@ func (r *RecipeDeploymentsDataSource) Schema(ctx context.Context, req datasource
 								},
 								"finish_time": schema.StringAttribute{
 									Computed: true,
-									Validators: []validator.String{
-										validators.IsRFC3339(),
-									},
 								},
 								"instance_status_count": schema.SingleNestedAttribute{
 									Computed: true,
@@ -81,22 +75,9 @@ func (r *RecipeDeploymentsDataSource) Schema(ctx context.Context, req datasource
 								},
 								"start_time": schema.StringAttribute{
 									Computed: true,
-									Validators: []validator.String{
-										validators.IsRFC3339(),
-									},
 								},
 								"status": schema.StringAttribute{
-									Computed: true,
-									Validators: []validator.String{
-										stringvalidator.OneOf(
-											"pending",
-											"running",
-											"stopped",
-											"succeeded",
-											"failed",
-											"deploying",
-										),
-									},
+									Computed:    true,
 									Description: `must be one of ["pending", "running", "stopped", "succeeded", "failed", "deploying"]`,
 								},
 							},
@@ -124,12 +105,7 @@ func (r *RecipeDeploymentsDataSource) Schema(ctx context.Context, req datasource
 									Computed: true,
 								},
 								"protocol": schema.StringAttribute{
-									Computed: true,
-									Validators: []validator.String{
-										stringvalidator.OneOf(
-											"http",
-										),
-									},
+									Computed:    true,
 									Description: `must be one of ["http"]`,
 								},
 							},
@@ -159,12 +135,7 @@ func (r *RecipeDeploymentsDataSource) Schema(ctx context.Context, req datasource
 											Computed: true,
 										},
 										"protocol": schema.StringAttribute{
-											Computed: true,
-											Validators: []validator.String{
-												stringvalidator.OneOf(
-													"http",
-												),
-											},
+											Computed:    true,
 											Description: `must be one of ["http"]`,
 										},
 									},

--- a/internal/provider/recipes_data_source.go
+++ b/internal/provider/recipes_data_source.go
@@ -8,10 +8,8 @@ import (
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk"
 	"github.com/squat/terraform-provider-saladcloud/internal/sdk/pkg/models/operations"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -71,12 +69,7 @@ func (r *RecipesDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 									Computed: true,
 								},
 								"protocol": schema.StringAttribute{
-									Computed: true,
-									Validators: []validator.String{
-										stringvalidator.OneOf(
-											"http",
-										),
-									},
+									Computed:    true,
 									Description: `must be one of ["http"]`,
 								},
 							},

--- a/internal/provider/reflect/number.go
+++ b/internal/provider/reflect/number.go
@@ -206,8 +206,7 @@ func Number(ctx context.Context, typ attr.Type, val tftypes.Value, target reflec
 		} else if acc == big.Below {
 			if floatResult == math.Inf(-1) || floatResult == -math.MaxFloat64 {
 				floatResult = -math.MaxFloat64
-				//lint:ignore SA4026 this is generated code
-			} else if floatResult == -0.0 || floatResult == -math.SmallestNonzeroFloat64 { //nolint:staticcheck
+			} else if floatResult == 0.0 || floatResult == -math.SmallestNonzeroFloat64 {
 				floatResult = math.SmallestNonzeroFloat64
 			} else {
 				err := fmt.Errorf("not sure how to round %s and %f", acc, floatResult)

--- a/internal/sdk/pkg/utils/utils.go
+++ b/internal/sdk/pkg/utils/utils.go
@@ -81,8 +81,6 @@ func parseStructTag(tagKey string, field reflect.StructField) map[string]string 
 			parts = append(parts, "true")
 		case 2:
 			// key=value option
-			//lint:ignore SA4011 this is generated code
-			break
 		default:
 			// invalid option
 			continue

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -148,8 +148,8 @@ func New(opts ...SDKOption) *SDK {
 			Language:          "go",
 			OpenAPIDocVersion: "1.0.0-alpha.56",
 			SDKVersion:        "0.0.1",
-			GenVersion:        "2.185.0",
-			UserAgent:         "speakeasy-sdk/go 0.0.1 2.185.0 1.0.0-alpha.56 saladcloud",
+			GenVersion:        "2.187.7",
+			UserAgent:         "speakeasy-sdk/go 0.0.1 2.187.7 1.0.0-alpha.56 saladcloud",
 		},
 	}
 	for _, opt := range opts {


### PR DESCRIPTION
Makefile: bump speakeasy and remove workarounds for issues

I filed two issues in the speakeasy CLI repo:
1. https://github.com/speakeasy-api/speakeasy/issues/326; and
2. https://github.com/speakeasy-api/speakeasy/issues/327.

Now that these issues are resolved in the latest version of speakeasy, I
can remove the workarounds for them.
