### PR TITLE
fix openapi spec

### DIFF
--- a/docs/data-sources/container_group.md
+++ b/docs/data-sources/container_group.md
@@ -31,6 +31,7 @@ data "saladcloud_container_group" "my_containergroup" {
 
 ### Read-Only
 
+- `autostart_policy` (Boolean)
 - `container` (Attributes) Represents a container (see [below for nested schema](#nestedatt--container))
 - `country_codes` (List of String)
 - `create_time` (String)

--- a/docs/data-sources/container_groups.md
+++ b/docs/data-sources/container_groups.md
@@ -36,6 +36,7 @@ data "saladcloud_container_groups" "my_containergroups" {
 
 Read-Only:
 
+- `autostart_policy` (Boolean)
 - `container` (Attributes) Represents a container (see [below for nested schema](#nestedatt--items--container))
 - `country_codes` (List of String)
 - `create_time` (String)

--- a/docs/resources/container_group.md
+++ b/docs/resources/container_group.md
@@ -177,7 +177,6 @@ resource "saladcloud_container_group" "my_containergroup" {
 ### Required
 
 - `container` (Attributes) Represents a container (see [below for nested schema](#nestedatt--container))
-- `display_name` (String)
 - `name` (String)
 - `organization_name` (String) The unique organization name
 - `project_name` (String) The unique project name
@@ -187,6 +186,7 @@ resource "saladcloud_container_group" "my_containergroup" {
 ### Optional
 
 - `country_codes` (List of String)
+- `display_name` (String)
 - `liveness_probe` (Attributes) Represents container group probe (see [below for nested schema](#nestedatt--liveness_probe))
 - `networking` (Attributes) Represents container group networking parameters (see [below for nested schema](#nestedatt--networking))
 - `readiness_probe` (Attributes) Represents container group probe (see [below for nested schema](#nestedatt--readiness_probe))
@@ -194,6 +194,7 @@ resource "saladcloud_container_group" "my_containergroup" {
 
 ### Read-Only
 
+- `autostart_policy` (Boolean)
 - `create_time` (String)
 - `current_state` (Attributes) Represents a container group state (see [below for nested schema](#nestedatt--current_state))
 - `id` (String) The ID of this resource.

--- a/internal/provider/containergroup_data_source.go
+++ b/internal/provider/containergroup_data_source.go
@@ -29,6 +29,7 @@ type ContainerGroupDataSource struct {
 
 // ContainerGroupDataSourceModel describes the data model.
 type ContainerGroupDataSourceModel struct {
+	AutostartPolicy  types.Bool                `tfsdk:"autostart_policy"`
 	Container        Container1                `tfsdk:"container"`
 	CountryCodes     []types.String            `tfsdk:"country_codes"`
 	CreateTime       types.String              `tfsdk:"create_time"`
@@ -58,6 +59,9 @@ func (r *ContainerGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 		MarkdownDescription: "ContainerGroup DataSource",
 
 		Attributes: map[string]schema.Attribute{
+			"autostart_policy": schema.BoolAttribute{
+				Computed: true,
+			},
 			"container": schema.SingleNestedAttribute{
 				Computed: true,
 				Attributes: map[string]schema.Attribute{

--- a/internal/provider/containergroup_data_source_sdk.go
+++ b/internal/provider/containergroup_data_source_sdk.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (r *ContainerGroupDataSourceModel) RefreshFromGetResponse(resp *shared.ContainerGroup) {
+	r.AutostartPolicy = types.BoolValue(resp.AutostartPolicy)
 	r.Container.Command = nil
 	for _, v := range resp.Container.Command {
 		r.Container.Command = append(r.Container.Command, types.StringValue(v))
@@ -73,7 +74,11 @@ func (r *ContainerGroupDataSourceModel) RefreshFromGetResponse(resp *shared.Cont
 	r.CurrentState.InstanceStatusCount.RunningCount = types.Int64Value(resp.CurrentState.InstanceStatusCount.RunningCount)
 	r.CurrentState.StartTime = types.StringValue(resp.CurrentState.StartTime.Format(time.RFC3339Nano))
 	r.CurrentState.Status = types.StringValue(string(resp.CurrentState.Status))
-	r.DisplayName = types.StringValue(resp.DisplayName)
+	if resp.DisplayName != nil {
+		r.DisplayName = types.StringValue(*resp.DisplayName)
+	} else {
+		r.DisplayName = types.StringNull()
+	}
 	r.ID = types.StringValue(resp.ID)
 	if resp.LivenessProbe == nil {
 		r.LivenessProbe = nil

--- a/internal/provider/containergroup_resource.go
+++ b/internal/provider/containergroup_resource.go
@@ -39,6 +39,7 @@ type ContainerGroupResource struct {
 
 // ContainerGroupResourceModel describes the resource data model.
 type ContainerGroupResourceModel struct {
+	AutostartPolicy  types.Bool                `tfsdk:"autostart_policy"`
 	Container        Container                 `tfsdk:"container"`
 	CountryCodes     []types.String            `tfsdk:"country_codes"`
 	CreateTime       types.String              `tfsdk:"create_time"`
@@ -66,6 +67,9 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 		MarkdownDescription: "ContainerGroup Resource",
 
 		Attributes: map[string]schema.Attribute{
+			"autostart_policy": schema.BoolAttribute{
+				Computed: true,
+			},
 			"container": schema.SingleNestedAttribute{
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplace(),
@@ -351,7 +355,8 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 				Description: `Represents a container group state`,
 			},
 			"display_name": schema.StringAttribute{
-				Required: true,
+				Computed: true,
+				Optional: true,
 			},
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/containergroup_resource_sdk.go
+++ b/internal/provider/containergroup_resource_sdk.go
@@ -406,6 +406,7 @@ func (r *ContainerGroupResourceModel) ToDeleteSDKType() *shared.CreateContainerG
 }
 
 func (r *ContainerGroupResourceModel) RefreshFromGetResponse(resp *shared.ContainerGroup) {
+	r.AutostartPolicy = types.BoolValue(resp.AutostartPolicy)
 	r.Container.Command = nil
 	for _, v := range resp.Container.Command {
 		r.Container.Command = append(r.Container.Command, types.StringValue(v))
@@ -470,7 +471,11 @@ func (r *ContainerGroupResourceModel) RefreshFromGetResponse(resp *shared.Contai
 	r.CurrentState.InstanceStatusCount.RunningCount = types.Int64Value(resp.CurrentState.InstanceStatusCount.RunningCount)
 	r.CurrentState.StartTime = types.StringValue(resp.CurrentState.StartTime.Format(time.RFC3339Nano))
 	r.CurrentState.Status = types.StringValue(string(resp.CurrentState.Status))
-	r.DisplayName = types.StringValue(resp.DisplayName)
+	if resp.DisplayName != nil {
+		r.DisplayName = types.StringValue(*resp.DisplayName)
+	} else {
+		r.DisplayName = types.StringNull()
+	}
 	r.ID = types.StringValue(resp.ID)
 	if resp.LivenessProbe == nil {
 		r.LivenessProbe = nil

--- a/internal/provider/containergroups_data_source.go
+++ b/internal/provider/containergroups_data_source.go
@@ -49,6 +49,9 @@ func (r *ContainerGroupsDataSource) Schema(ctx context.Context, req datasource.S
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"autostart_policy": schema.BoolAttribute{
+							Computed: true,
+						},
 						"container": schema.SingleNestedAttribute{
 							Computed: true,
 							Attributes: map[string]schema.Attribute{

--- a/internal/provider/containergroups_data_source_sdk.go
+++ b/internal/provider/containergroups_data_source_sdk.go
@@ -12,6 +12,7 @@ func (r *ContainerGroupsDataSourceModel) RefreshFromGetResponse(resp *shared.Con
 	r.Items = nil
 	for _, itemsItem := range resp.Items {
 		var items1 ContainerGroup
+		items1.AutostartPolicy = types.BoolValue(itemsItem.AutostartPolicy)
 		items1.Container.Command = nil
 		for _, v := range itemsItem.Container.Command {
 			items1.Container.Command = append(items1.Container.Command, types.StringValue(v))
@@ -76,7 +77,11 @@ func (r *ContainerGroupsDataSourceModel) RefreshFromGetResponse(resp *shared.Con
 		items1.CurrentState.InstanceStatusCount.RunningCount = types.Int64Value(itemsItem.CurrentState.InstanceStatusCount.RunningCount)
 		items1.CurrentState.StartTime = types.StringValue(itemsItem.CurrentState.StartTime.Format(time.RFC3339Nano))
 		items1.CurrentState.Status = types.StringValue(string(itemsItem.CurrentState.Status))
-		items1.DisplayName = types.StringValue(itemsItem.DisplayName)
+		if itemsItem.DisplayName != nil {
+			items1.DisplayName = types.StringValue(*itemsItem.DisplayName)
+		} else {
+			items1.DisplayName = types.StringNull()
+		}
 		items1.ID = types.StringValue(itemsItem.ID)
 		if itemsItem.LivenessProbe == nil {
 			items1.LivenessProbe = nil

--- a/internal/provider/type_container_group.go
+++ b/internal/provider/type_container_group.go
@@ -5,18 +5,19 @@ package provider
 import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type ContainerGroup struct {
-	Container      Container1                `tfsdk:"container"`
-	CountryCodes   []types.String            `tfsdk:"country_codes"`
-	CreateTime     types.String              `tfsdk:"create_time"`
-	CurrentState   ContainerGroupState       `tfsdk:"current_state"`
-	DisplayName    types.String              `tfsdk:"display_name"`
-	ID             types.String              `tfsdk:"id"`
-	LivenessProbe  *ContainerGroupProbe      `tfsdk:"liveness_probe"`
-	Name           types.String              `tfsdk:"name"`
-	Networking     *ContainerGroupNetworking `tfsdk:"networking"`
-	ReadinessProbe *ContainerGroupProbe      `tfsdk:"readiness_probe"`
-	Replicas       types.Int64               `tfsdk:"replicas"`
-	RestartPolicy  types.String              `tfsdk:"restart_policy"`
-	StartupProbe   *ContainerGroupProbe      `tfsdk:"startup_probe"`
-	UpdateTime     types.String              `tfsdk:"update_time"`
+	AutostartPolicy types.Bool                `tfsdk:"autostart_policy"`
+	Container       Container1                `tfsdk:"container"`
+	CountryCodes    []types.String            `tfsdk:"country_codes"`
+	CreateTime      types.String              `tfsdk:"create_time"`
+	CurrentState    ContainerGroupState       `tfsdk:"current_state"`
+	DisplayName     types.String              `tfsdk:"display_name"`
+	ID              types.String              `tfsdk:"id"`
+	LivenessProbe   *ContainerGroupProbe      `tfsdk:"liveness_probe"`
+	Name            types.String              `tfsdk:"name"`
+	Networking      *ContainerGroupNetworking `tfsdk:"networking"`
+	ReadinessProbe  *ContainerGroupProbe      `tfsdk:"readiness_probe"`
+	Replicas        types.Int64               `tfsdk:"replicas"`
+	RestartPolicy   types.String              `tfsdk:"restart_policy"`
+	StartupProbe    *ContainerGroupProbe      `tfsdk:"startup_probe"`
+	UpdateTime      types.String              `tfsdk:"update_time"`
 }

--- a/internal/sdk/pkg/models/shared/containergroup.go
+++ b/internal/sdk/pkg/models/shared/containergroup.go
@@ -9,13 +9,14 @@ import (
 
 // ContainerGroup - Represents a container group
 type ContainerGroup struct {
+	AutostartPolicy bool `json:"autostart_policy"`
 	// Represents a container
 	Container    Container     `json:"container"`
 	CountryCodes []CountryCode `json:"country_codes,omitempty"`
 	CreateTime   time.Time     `json:"create_time"`
 	// Represents a container group state
 	CurrentState ContainerGroupState `json:"current_state"`
-	DisplayName  string              `json:"display_name"`
+	DisplayName  *string             `json:"display_name,omitempty"`
 	ID           string              `json:"id"`
 	// Represents container group probe
 	LivenessProbe *ContainerGroupProbe `json:"liveness_probe,omitempty"`
@@ -40,6 +41,13 @@ func (c *ContainerGroup) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return nil
+}
+
+func (o *ContainerGroup) GetAutostartPolicy() bool {
+	if o == nil {
+		return false
+	}
+	return o.AutostartPolicy
 }
 
 func (o *ContainerGroup) GetContainer() Container {
@@ -70,9 +78,9 @@ func (o *ContainerGroup) GetCurrentState() ContainerGroupState {
 	return o.CurrentState
 }
 
-func (o *ContainerGroup) GetDisplayName() string {
+func (o *ContainerGroup) GetDisplayName() *string {
 	if o == nil {
-		return ""
+		return nil
 	}
 	return o.DisplayName
 }

--- a/patch.sh
+++ b/patch.sh
@@ -11,6 +11,9 @@ bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/c
 bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].patch.x-speakeasy-entity-operation = "ContainerGroup#update"' saladcloud.yaml
 bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].delete.x-speakeasy-entity-operation = "ContainerGroup#delete"' saladcloud.yaml
 bin/yq -i '.components.schemas.ContainerGroup.x-speakeasy-entity = "ContainerGroup"' saladcloud.yaml
+bin/yq -i '.components.schemas.ContainerGroup.properties.autostart_policy = {"type": "boolean"}' saladcloud.yaml
+bin/yq -i 'del(.components.schemas.ContainerGroup.required[] | select(. == "display_name"))' saladcloud.yaml
+bin/yq -i '.components.schemas.ContainerGroup.required += ["autostart_policy"]' saladcloud.yaml
 bin/yq -i '.components.parameters.container_group_name.x-speakeasy-match = "name"' saladcloud.yaml
 # Container Group Instances
 bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}/instances"].get.x-speakeasy-entity-operation = "ContainerGroupInstances#read"' saladcloud.yaml

--- a/saladcloud.yaml
+++ b/saladcloud.yaml
@@ -730,16 +730,18 @@ components:
         update_time:
           format: date-time
           type: string
+        autostart_policy:
+          type: boolean
       required:
         - id
         - name
-        - display_name
         - container
         - restart_policy
         - replicas
         - current_state
         - create_time
         - update_time
+        - autostart_policy
       type: object
       x-speakeasy-entity: ContainerGroup
     ContainerGroupInstanceStatusCount:


### PR DESCRIPTION
OpenAPI Specification: fix some container group properties

The specification published by SaladCloud doesn't match what the API
actually requires:
* an autostart_policy is required
* display_name is not required

This adjusts the patching script to reflect this.
