### PR TITLE
patch.sh: refactor how YAML is patched

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ saladcloud.json:
 	curl https://docs.salad.com/reference/saladcloud-openapi-spec?json=on | jq .doc.body -r | head --lines=-1 | tail --lines=+2
 
 saladcloud.yaml: saladcloud.json $(GOJSONTOYAML_BINARY) $(YQ_BINARY) patch.sh
-	cat $< | $(GOJSONTOYAML_BINARY) > $@ && sh patch.sh
+	cat $< | $(GOJSONTOYAML_BINARY) | sh patch.sh > $@
 
 files.gen: saladcloud.yaml $(SPEAKEASY_BINARY) gen.yaml
 	$(SPEAKEASY_BINARY) generate sdk --lang terraform --schema $< --out .

--- a/patch.sh
+++ b/patch.sh
@@ -1,49 +1,53 @@
 #! /usr/bin/env sh
+# Setup
+F=$(mktemp)
+trap 'cat "$F"; exit' EXIT
+cat - > "$F"
 # General Patches
-bin/yq -i '.info.title = "SaladCloud Provider"' saladcloud.yaml
-bin/yq -i '.info.description = "The SaladCloud provider enables declaratively managing resources provided by SaladCloud. The provider needs to be configured with the proper credentials before it can be used.\n\nFor information on obtaining an API key for SaladCloud, refer to [Authentication](https://docs.salad.com/reference/api-reference#authentication) from the [SaladCloud Documentation](https://docs.salad.com/)."' saladcloud.yaml
-bin/yq -i '.components.schemas.ContainerResourceRequirements.properties.memory.maximum = 30720' saladcloud.yaml
-bin/yq -i '.components.schemas.ContainerResourceRequirements.properties.gpu_class.deprecated = true' saladcloud.yaml
-bin/yq -i '.components.schemas.ContainerResourceRequirements.properties.gpu_classes = {"nullable": true, "type": "array", "items": {"type": "string"}}' saladcloud.yaml
+bin/yq -i '.info.title = "SaladCloud Provider"' "$F"
+bin/yq -i '.info.description = "The SaladCloud provider enables declaratively managing resources provided by SaladCloud. The provider needs to be configured with the proper credentials before it can be used.\n\nFor information on obtaining an API key for SaladCloud, refer to [Authentication](https://docs.salad.com/reference/api-reference#authentication) from the [SaladCloud Documentation](https://docs.salad.com/)."' "$F"
+bin/yq -i '.components.schemas.ContainerResourceRequirements.properties.memory.maximum = 30720' "$F"
+bin/yq -i '.components.schemas.ContainerResourceRequirements.properties.gpu_class.deprecated = true' "$F"
+bin/yq -i '.components.schemas.ContainerResourceRequirements.properties.gpu_classes = {"nullable": true, "type": "array", "items": {"type": "string"}}' "$F"
 # Container Group
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers"].post.x-speakeasy-entity-operation = "ContainerGroup#create"' saladcloud.yaml
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].get.x-speakeasy-entity-operation = "ContainerGroup#read"' saladcloud.yaml
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].patch.x-speakeasy-entity-operation = "ContainerGroup#update"' saladcloud.yaml
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].delete.x-speakeasy-entity-operation = "ContainerGroup#delete"' saladcloud.yaml
-bin/yq -i '.components.schemas.ContainerGroup.x-speakeasy-entity = "ContainerGroup"' saladcloud.yaml
-bin/yq -i '.components.schemas.ContainerGroup.properties.autostart_policy = {"type": "boolean"}' saladcloud.yaml
-bin/yq -i 'del(.components.schemas.ContainerGroup.required[] | select(. == "display_name"))' saladcloud.yaml
-bin/yq -i '.components.schemas.ContainerGroup.required += ["autostart_policy"]' saladcloud.yaml
-bin/yq -i '.components.parameters.container_group_name.x-speakeasy-match = "name"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers"].post.x-speakeasy-entity-operation = "ContainerGroup#create"' "$F"
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].get.x-speakeasy-entity-operation = "ContainerGroup#read"' "$F"
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].patch.x-speakeasy-entity-operation = "ContainerGroup#update"' "$F"
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].delete.x-speakeasy-entity-operation = "ContainerGroup#delete"' "$F"
+bin/yq -i '.components.schemas.ContainerGroup.x-speakeasy-entity = "ContainerGroup"' "$F"
+bin/yq -i '.components.schemas.ContainerGroup.properties.autostart_policy = {"type": "boolean"}' "$F"
+bin/yq -i 'del(.components.schemas.ContainerGroup.required[] | select(. == "display_name"))' "$F"
+bin/yq -i '.components.schemas.ContainerGroup.required += ["autostart_policy"]' "$F"
+bin/yq -i '.components.parameters.container_group_name.x-speakeasy-match = "name"' "$F"
 # Container Group Instances
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}/instances"].get.x-speakeasy-entity-operation = "ContainerGroupInstances#read"' saladcloud.yaml
-bin/yq -i '.components.schemas.ContainerGroupInstances.x-speakeasy-entity = "ContainerGroupInstances"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}/instances"].get.x-speakeasy-entity-operation = "ContainerGroupInstances#read"' "$F"
+bin/yq -i '.components.schemas.ContainerGroupInstances.x-speakeasy-entity = "ContainerGroupInstances"' "$F"
 # Container Groups
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers"].get.x-speakeasy-entity-operation = "ContainerGroups#read"' saladcloud.yaml
-bin/yq -i '.components.schemas.ContainerGroupList.x-speakeasy-entity = "ContainerGroups"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers"].get.x-speakeasy-entity-operation = "ContainerGroups#read"' "$F"
+bin/yq -i '.components.schemas.ContainerGroupList.x-speakeasy-entity = "ContainerGroups"' "$F"
 # GPU Classes
-bin/yq -i '.paths.["/organizations/{organization_name}/gpu-classes"].get.x-speakeasy-entity-operation = "GPUClasses#read"' saladcloud.yaml
-bin/yq -i '.components.schemas.GpuClassesList.x-speakeasy-entity = "GPUClasses"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/gpu-classes"].get.x-speakeasy-entity-operation = "GPUClasses#read"' "$F"
+bin/yq -i '.components.schemas.GpuClassesList.x-speakeasy-entity = "GPUClasses"' "$F"
 # Quotas
-bin/yq -i '.paths.["/organizations/{organization_name}/quotas"].get.x-speakeasy-entity-operation = "Quotas#read"' saladcloud.yaml
-bin/yq -i '.components.schemas.Quotas.x-speakeasy-entity = "Quotas"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/quotas"].get.x-speakeasy-entity-operation = "Quotas#read"' "$F"
+bin/yq -i '.components.schemas.Quotas.x-speakeasy-entity = "Quotas"' "$F"
 # Recipe
-bin/yq -i '.paths.["/organizations/{organization_name}/recipes/{recipe_name}"].get.x-speakeasy-entity-operation = "Recipe#read"' saladcloud.yaml
-bin/yq -i '.components.schemas.Recipe.x-speakeasy-entity = "Recipe"' saladcloud.yaml
-bin/yq -i '.components.parameters.recipe_name.x-speakeasy-match = "name"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/recipes/{recipe_name}"].get.x-speakeasy-entity-operation = "Recipe#read"' "$F"
+bin/yq -i '.components.schemas.Recipe.x-speakeasy-entity = "Recipe"' "$F"
+bin/yq -i '.components.parameters.recipe_name.x-speakeasy-match = "name"' "$F"
 # Recipes
-bin/yq -i '.paths.["/organizations/{organization_name}/recipes"].get.x-speakeasy-entity-operation = "Recipes#read"' saladcloud.yaml
-bin/yq -i '.components.schemas.RecipeList.x-speakeasy-entity = "Recipes"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/recipes"].get.x-speakeasy-entity-operation = "Recipes#read"' "$F"
+bin/yq -i '.components.schemas.RecipeList.x-speakeasy-entity = "Recipes"' "$F"
 # Recipe Deployment
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments"].post.x-speakeasy-entity-operation = "RecipeDeployment#create"' saladcloud.yaml
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments/{recipe_deployment_name}"].get.x-speakeasy-entity-operation = "RecipeDeployment#read"' saladcloud.yaml
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments/{recipe_deployment_name}"].patch.x-speakeasy-entity-operation = "RecipeDeployment#update"' saladcloud.yaml
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments/{recipe_deployment_name}"].delete.x-speakeasy-entity-operation = "RecipeDeployment#delete"' saladcloud.yaml
-bin/yq -i '.components.schemas.RecipeDeployment.x-speakeasy-entity = "RecipeDeployment"' saladcloud.yaml
-bin/yq -i '.components.parameters.recipe_deployment_name.x-speakeasy-match = "name"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments"].post.x-speakeasy-entity-operation = "RecipeDeployment#create"' "$F"
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments/{recipe_deployment_name}"].get.x-speakeasy-entity-operation = "RecipeDeployment#read"' "$F"
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments/{recipe_deployment_name}"].patch.x-speakeasy-entity-operation = "RecipeDeployment#update"' "$F"
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments/{recipe_deployment_name}"].delete.x-speakeasy-entity-operation = "RecipeDeployment#delete"' "$F"
+bin/yq -i '.components.schemas.RecipeDeployment.x-speakeasy-entity = "RecipeDeployment"' "$F"
+bin/yq -i '.components.parameters.recipe_deployment_name.x-speakeasy-match = "name"' "$F"
 # Recipe Deployment Instances
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments/{recipe_deployment_name}/instances"].get.x-speakeasy-entity-operation = "RecipeDeploymentInstances#read"' saladcloud.yaml
-bin/yq -i '.components.schemas.RecipeDeploymentInstances.x-speakeasy-entity = "RecipeDeploymentInstances"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments/{recipe_deployment_name}/instances"].get.x-speakeasy-entity-operation = "RecipeDeploymentInstances#read"' "$F"
+bin/yq -i '.components.schemas.RecipeDeploymentInstances.x-speakeasy-entity = "RecipeDeploymentInstances"' "$F"
 # Recipe Deployments
-bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments"].get.x-speakeasy-entity-operation = "RecipeDeployments#read"' saladcloud.yaml
-bin/yq -i '.components.schemas.RecipeDeploymentList.x-speakeasy-entity = "RecipeDeployments"' saladcloud.yaml
+bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/recipe-deployments"].get.x-speakeasy-entity-operation = "RecipeDeployments#read"' "$F"
+bin/yq -i '.components.schemas.RecipeDeploymentList.x-speakeasy-entity = "RecipeDeployments"' "$F"


### PR DESCRIPTION
This commit refactors the patching of the OpenAPI spec's YAML document.
The patching now happens using STDIN and STDOUT. This is really useful
to be able to re-use Makefile / patching infrastructure for other
OpenAPI specs with different names.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
