### PR TITLE
fix openapi spec

### DIFF
--- a/docs/resources/container_group.md
+++ b/docs/resources/container_group.md
@@ -14,13 +14,14 @@ ContainerGroup Resource
 
 ```terraform
 resource "saladcloud_container_group" "my_containergroup" {
+  autostart_policy = false
   container = {
     command = [
       "...",
     ]
     environment_variables = {
-      "Northeast" = "..."
-      "Cadillac"  = "..."
+      "transmit" = "..."
+      "salmon"   = "..."
     }
     image = "...my_image..."
     logging = {
@@ -34,7 +35,7 @@ resource "saladcloud_container_group" "my_containergroup" {
       }
       tcp = {
         host = "...my_host..."
-        port = 6
+        port = 4
       }
     }
     registry_authentication = {
@@ -44,27 +45,27 @@ resource "saladcloud_container_group" "my_containergroup" {
       }
       basic = {
         password = "...my_password..."
-        username = "Gregorio42"
+        username = "Jerel_Haag"
       }
       docker_hub = {
         personal_access_token = "...my_personal_access_token..."
-        username              = "Letitia20"
+        username              = "Jonatan60"
       }
       gcp_gcr = {
         service_key = "...my_service_key..."
       }
     }
     resources = {
-      cpu       = 6
+      cpu       = 9
       gpu_class = "...my_gpu_class..."
       gpu_classes = [
         "...",
       ]
-      memory = 9
+      memory = 5
     }
   }
   country_codes = [
-    "la",
+    "cg",
   ]
   display_name = "...my_display_name..."
   liveness_probe = {
@@ -73,35 +74,35 @@ resource "saladcloud_container_group" "my_containergroup" {
         "...",
       ]
     }
-    failure_threshold = 2
+    failure_threshold = 10
     grpc = {
-      port    = 10
+      port    = 1
       service = "...my_service..."
     }
     http = {
       headers = [
         {
-          name  = "Maxine Aufderhar"
+          name  = "Thomas Larkin"
           value = "...my_value..."
         },
       ]
       path   = "...my_path..."
-      port   = 5
+      port   = 1
       scheme = "http"
     }
-    initial_delay_seconds = 1
-    period_seconds        = 5
-    success_threshold     = 3
+    initial_delay_seconds = 5
+    period_seconds        = 3
+    success_threshold     = 10
     tcp = {
-      port = 10
+      port = 5
     }
-    timeout_seconds = 5
+    timeout_seconds = 9
   }
-  name = "Rick Dickinson"
+  name = "Annie Powlowski"
   networking = {
-    auth     = false
+    auth     = true
     dns      = "...my_dns..."
-    port     = 8
+    port     = 2
     protocol = "http"
   }
   organization_name = "...my_organization_name..."
@@ -112,15 +113,15 @@ resource "saladcloud_container_group" "my_containergroup" {
         "...",
       ]
     }
-    failure_threshold = 2
+    failure_threshold = 10
     grpc = {
-      port    = 10
+      port    = 3
       service = "...my_service..."
     }
     http = {
       headers = [
         {
-          name  = "Mr. Patsy Kuhn"
+          name  = "Cody Auer"
           value = "...my_value..."
         },
       ]
@@ -176,6 +177,7 @@ resource "saladcloud_container_group" "my_containergroup" {
 
 ### Required
 
+- `autostart_policy` (Boolean)
 - `container` (Attributes) Represents a container (see [below for nested schema](#nestedatt--container))
 - `name` (String)
 - `organization_name` (String) The unique organization name
@@ -194,7 +196,6 @@ resource "saladcloud_container_group" "my_containergroup" {
 
 ### Read-Only
 
-- `autostart_policy` (Boolean)
 - `create_time` (String)
 - `current_state` (Attributes) Represents a container group state (see [below for nested schema](#nestedatt--current_state))
 - `id` (String) The ID of this resource.
@@ -205,12 +206,12 @@ resource "saladcloud_container_group" "my_containergroup" {
 
 Required:
 
-- `command` (List of String)
 - `image` (String)
 - `resources` (Attributes) Represents a container resource requirements (see [below for nested schema](#nestedatt--container--resources))
 
 Optional:
 
+- `command` (List of String)
 - `environment_variables` (Map of String)
 - `logging` (Attributes) (see [below for nested schema](#nestedatt--container--logging))
 - `registry_authentication` (Attributes) (see [below for nested schema](#nestedatt--container--registry_authentication))

--- a/examples/resources/saladcloud_container_group/resource.tf
+++ b/examples/resources/saladcloud_container_group/resource.tf
@@ -1,11 +1,12 @@
 resource "saladcloud_container_group" "my_containergroup" {
+  autostart_policy = false
   container = {
     command = [
       "...",
     ]
     environment_variables = {
-      "Northeast" = "..."
-      "Cadillac"  = "..."
+      "transmit" = "..."
+      "salmon"   = "..."
     }
     image = "...my_image..."
     logging = {
@@ -19,7 +20,7 @@ resource "saladcloud_container_group" "my_containergroup" {
       }
       tcp = {
         host = "...my_host..."
-        port = 6
+        port = 4
       }
     }
     registry_authentication = {
@@ -29,27 +30,27 @@ resource "saladcloud_container_group" "my_containergroup" {
       }
       basic = {
         password = "...my_password..."
-        username = "Gregorio42"
+        username = "Jerel_Haag"
       }
       docker_hub = {
         personal_access_token = "...my_personal_access_token..."
-        username              = "Letitia20"
+        username              = "Jonatan60"
       }
       gcp_gcr = {
         service_key = "...my_service_key..."
       }
     }
     resources = {
-      cpu       = 6
+      cpu       = 9
       gpu_class = "...my_gpu_class..."
       gpu_classes = [
         "...",
       ]
-      memory = 9
+      memory = 5
     }
   }
   country_codes = [
-    "la",
+    "cg",
   ]
   display_name = "...my_display_name..."
   liveness_probe = {
@@ -58,35 +59,35 @@ resource "saladcloud_container_group" "my_containergroup" {
         "...",
       ]
     }
-    failure_threshold = 2
+    failure_threshold = 10
     grpc = {
-      port    = 10
+      port    = 1
       service = "...my_service..."
     }
     http = {
       headers = [
         {
-          name  = "Maxine Aufderhar"
+          name  = "Thomas Larkin"
           value = "...my_value..."
         },
       ]
       path   = "...my_path..."
-      port   = 5
+      port   = 1
       scheme = "http"
     }
-    initial_delay_seconds = 1
-    period_seconds        = 5
-    success_threshold     = 3
+    initial_delay_seconds = 5
+    period_seconds        = 3
+    success_threshold     = 10
     tcp = {
-      port = 10
+      port = 5
     }
-    timeout_seconds = 5
+    timeout_seconds = 9
   }
-  name = "Rick Dickinson"
+  name = "Annie Powlowski"
   networking = {
-    auth     = false
+    auth     = true
     dns      = "...my_dns..."
-    port     = 8
+    port     = 2
     protocol = "http"
   }
   organization_name = "...my_organization_name..."
@@ -97,15 +98,15 @@ resource "saladcloud_container_group" "my_containergroup" {
         "...",
       ]
     }
-    failure_threshold = 2
+    failure_threshold = 10
     grpc = {
-      port    = 10
+      port    = 3
       service = "...my_service..."
     }
     http = {
       headers = [
         {
-          name  = "Mr. Patsy Kuhn"
+          name  = "Cody Auer"
           value = "...my_value..."
         },
       ]

--- a/internal/provider/containergroup_data_source_sdk.go
+++ b/internal/provider/containergroup_data_source_sdk.go
@@ -74,11 +74,7 @@ func (r *ContainerGroupDataSourceModel) RefreshFromGetResponse(resp *shared.Cont
 	r.CurrentState.InstanceStatusCount.RunningCount = types.Int64Value(resp.CurrentState.InstanceStatusCount.RunningCount)
 	r.CurrentState.StartTime = types.StringValue(resp.CurrentState.StartTime.Format(time.RFC3339Nano))
 	r.CurrentState.Status = types.StringValue(string(resp.CurrentState.Status))
-	if resp.DisplayName != nil {
-		r.DisplayName = types.StringValue(*resp.DisplayName)
-	} else {
-		r.DisplayName = types.StringNull()
-	}
+	r.DisplayName = types.StringValue(resp.DisplayName)
 	r.ID = types.StringValue(resp.ID)
 	if resp.LivenessProbe == nil {
 		r.LivenessProbe = nil

--- a/internal/provider/containergroup_resource.go
+++ b/internal/provider/containergroup_resource.go
@@ -68,7 +68,10 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 
 		Attributes: map[string]schema.Attribute{
 			"autostart_policy": schema.BoolAttribute{
-				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+				Required: true,
 			},
 			"container": schema.SingleNestedAttribute{
 				PlanModifiers: []planmodifier.Object{
@@ -77,10 +80,11 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 				Required: true,
 				Attributes: map[string]schema.Attribute{
 					"command": schema.ListAttribute{
+						Computed: true,
 						PlanModifiers: []planmodifier.List{
 							listplanmodifier.RequiresReplace(),
 						},
-						Required:    true,
+						Optional:    true,
 						ElementType: types.StringType,
 					},
 					"environment_variables": schema.MapAttribute{

--- a/internal/provider/containergroup_resource_sdk.go
+++ b/internal/provider/containergroup_resource_sdk.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (r *ContainerGroupResourceModel) ToCreateSDKType() *shared.CreateContainerGroup {
+	autostartPolicy := r.AutostartPolicy.ValueBool()
 	var command []string = nil
 	for _, commandItem := range r.Container.Command {
 		command = append(command, commandItem.ValueString())
@@ -361,16 +362,17 @@ func (r *ContainerGroupResourceModel) ToCreateSDKType() *shared.CreateContainerG
 		}
 	}
 	out := shared.CreateContainerGroup{
-		Container:      container,
-		CountryCodes:   countryCodes,
-		DisplayName:    displayName,
-		LivenessProbe:  livenessProbe,
-		Name:           name1,
-		Networking:     networking,
-		ReadinessProbe: readinessProbe,
-		Replicas:       replicas,
-		RestartPolicy:  restartPolicy,
-		StartupProbe:   startupProbe,
+		AutostartPolicy: autostartPolicy,
+		Container:       container,
+		CountryCodes:    countryCodes,
+		DisplayName:     displayName,
+		LivenessProbe:   livenessProbe,
+		Name:            name1,
+		Networking:      networking,
+		ReadinessProbe:  readinessProbe,
+		Replicas:        replicas,
+		RestartPolicy:   restartPolicy,
+		StartupProbe:    startupProbe,
 	}
 	return &out
 }
@@ -471,11 +473,7 @@ func (r *ContainerGroupResourceModel) RefreshFromGetResponse(resp *shared.Contai
 	r.CurrentState.InstanceStatusCount.RunningCount = types.Int64Value(resp.CurrentState.InstanceStatusCount.RunningCount)
 	r.CurrentState.StartTime = types.StringValue(resp.CurrentState.StartTime.Format(time.RFC3339Nano))
 	r.CurrentState.Status = types.StringValue(string(resp.CurrentState.Status))
-	if resp.DisplayName != nil {
-		r.DisplayName = types.StringValue(*resp.DisplayName)
-	} else {
-		r.DisplayName = types.StringNull()
-	}
+	r.DisplayName = types.StringValue(resp.DisplayName)
 	r.ID = types.StringValue(resp.ID)
 	if resp.LivenessProbe == nil {
 		r.LivenessProbe = nil

--- a/internal/provider/containergroups_data_source_sdk.go
+++ b/internal/provider/containergroups_data_source_sdk.go
@@ -77,11 +77,7 @@ func (r *ContainerGroupsDataSourceModel) RefreshFromGetResponse(resp *shared.Con
 		items1.CurrentState.InstanceStatusCount.RunningCount = types.Int64Value(itemsItem.CurrentState.InstanceStatusCount.RunningCount)
 		items1.CurrentState.StartTime = types.StringValue(itemsItem.CurrentState.StartTime.Format(time.RFC3339Nano))
 		items1.CurrentState.Status = types.StringValue(string(itemsItem.CurrentState.Status))
-		if itemsItem.DisplayName != nil {
-			items1.DisplayName = types.StringValue(*itemsItem.DisplayName)
-		} else {
-			items1.DisplayName = types.StringNull()
-		}
+		items1.DisplayName = types.StringValue(itemsItem.DisplayName)
 		items1.ID = types.StringValue(itemsItem.ID)
 		if itemsItem.LivenessProbe == nil {
 			items1.LivenessProbe = nil

--- a/internal/sdk/pkg/models/shared/containergroup.go
+++ b/internal/sdk/pkg/models/shared/containergroup.go
@@ -16,7 +16,7 @@ type ContainerGroup struct {
 	CreateTime   time.Time     `json:"create_time"`
 	// Represents a container group state
 	CurrentState ContainerGroupState `json:"current_state"`
-	DisplayName  *string             `json:"display_name,omitempty"`
+	DisplayName  string              `json:"display_name"`
 	ID           string              `json:"id"`
 	// Represents container group probe
 	LivenessProbe *ContainerGroupProbe `json:"liveness_probe,omitempty"`
@@ -78,9 +78,9 @@ func (o *ContainerGroup) GetCurrentState() ContainerGroupState {
 	return o.CurrentState
 }
 
-func (o *ContainerGroup) GetDisplayName() *string {
+func (o *ContainerGroup) GetDisplayName() string {
 	if o == nil {
-		return nil
+		return ""
 	}
 	return o.DisplayName
 }

--- a/internal/sdk/pkg/models/shared/createcontainergroup.go
+++ b/internal/sdk/pkg/models/shared/createcontainergroup.go
@@ -4,6 +4,7 @@ package shared
 
 // CreateContainerGroup - Represents a request to create a container group
 type CreateContainerGroup struct {
+	AutostartPolicy bool `json:"autostart_policy"`
 	// Represents a container
 	Container    CreateContainer `json:"container"`
 	CountryCodes []CountryCode   `json:"country_codes,omitempty"`
@@ -19,6 +20,13 @@ type CreateContainerGroup struct {
 	RestartPolicy  ContainerRestartPolicy `json:"restart_policy"`
 	// Represents container group probe
 	StartupProbe *ContainerGroupProbe `json:"startup_probe,omitempty"`
+}
+
+func (o *CreateContainerGroup) GetAutostartPolicy() bool {
+	if o == nil {
+		return false
+	}
+	return o.AutostartPolicy
 }
 
 func (o *CreateContainerGroup) GetContainer() CreateContainer {

--- a/patch.sh
+++ b/patch.sh
@@ -15,9 +15,11 @@ bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/c
 bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].patch.x-speakeasy-entity-operation = "ContainerGroup#update"' "$F"
 bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}"].delete.x-speakeasy-entity-operation = "ContainerGroup#delete"' "$F"
 bin/yq -i '.components.schemas.ContainerGroup.x-speakeasy-entity = "ContainerGroup"' "$F"
+bin/yq -i '.components.schemas.CreateContainerGroup.x-speakeasy-entity = "ContainerGroup"' "$F"
 bin/yq -i '.components.schemas.ContainerGroup.properties.autostart_policy = {"type": "boolean"}' "$F"
-bin/yq -i 'del(.components.schemas.ContainerGroup.required[] | select(. == "display_name"))' "$F"
 bin/yq -i '.components.schemas.ContainerGroup.required += ["autostart_policy"]' "$F"
+bin/yq -i '.components.schemas.CreateContainerGroup.properties.autostart_policy = {"type": "boolean"}' "$F"
+bin/yq -i '.components.schemas.CreateContainerGroup.required += ["autostart_policy"]' "$F"
 bin/yq -i '.components.parameters.container_group_name.x-speakeasy-match = "name"' "$F"
 # Container Group Instances
 bin/yq -i '.paths.["/organizations/{organization_name}/projects/{project_name}/containers/{container_group_name}/instances"].get.x-speakeasy-entity-operation = "ContainerGroupInstances#read"' "$F"

--- a/saladcloud.yaml
+++ b/saladcloud.yaml
@@ -735,6 +735,7 @@ components:
       required:
         - id
         - name
+        - display_name
         - container
         - restart_policy
         - replicas
@@ -1421,12 +1422,16 @@ components:
           $ref: '#/components/schemas/ContainerRestartPolicy'
         startup_probe:
           $ref: '#/components/schemas/ContainerGroupProbe'
+        autostart_policy:
+          type: boolean
       required:
         - name
         - container
         - restart_policy
         - replicas
+        - autostart_policy
       type: object
+      x-speakeasy-entity: ContainerGroup
     CreateContainerGroupNetworking:
       additionalProperties: false
       description: Represents container group networking parameters


### PR DESCRIPTION
patch.sh: fix OpenAPI spec

Currently, the ContainerGroup schema is used for creation as well as
reading, which is wrong: they have different properties and required
fields. This commit corrects this.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
