### PR TITLE
feat: add shm_size support to container group resources

### DIFF
--- a/internal/provider/containergroup_resource.go
+++ b/internal/provider/containergroup_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
@@ -287,6 +288,15 @@ func (r *ContainerGroupResource) Schema(ctx context.Context, req resource.Schema
 									int64planmodifier.RequiresReplace(),
 								},
 								Required: true,
+							},
+							"shm_size": schema.Int64Attribute{
+								Computed: true,
+								Optional: true,
+								Default:  int64default.StaticInt64(64),
+								PlanModifiers: []planmodifier.Int64{
+									int64planmodifier.RequiresReplace(),
+								},
+								Description: "Shared memory size in MB for /dev/shm (64-1073741824)",
 							},
 						},
 						Description: `Represents a container resource requirements`,

--- a/internal/provider/containergroup_resource_sdk.go
+++ b/internal/provider/containergroup_resource_sdk.go
@@ -110,11 +110,18 @@ func (r *ContainerGroupResourceModel) ToCreateSDKType() *shared.CreateContainerG
 		gpuClasses = append(gpuClasses, gpuClassesItem.ValueString())
 	}
 	memory := r.Container.Resources.Memory.ValueInt64()
+	shmSize := new(int64)
+	if !r.Container.Resources.ShmSize.IsUnknown() && !r.Container.Resources.ShmSize.IsNull() {
+		*shmSize = r.Container.Resources.ShmSize.ValueInt64()
+	} else {
+		shmSize = nil
+	}
 	resources := shared.ContainerResourceRequirements{
 		CPU:        cpu,
 		GpuClass:   gpuClass,
 		GpuClasses: gpuClasses,
 		Memory:     memory,
+		ShmSize:    shmSize,
 	}
 	container := shared.CreateContainer{
 		Command:                command,
@@ -457,6 +464,11 @@ func (r *ContainerGroupResourceModel) RefreshFromGetResponse(resp *shared.Contai
 		r.Container.Resources.GpuClasses = append(r.Container.Resources.GpuClasses, types.StringValue(v))
 	}
 	r.Container.Resources.Memory = types.Int64Value(resp.Container.Resources.Memory)
+	if resp.Container.Resources.ShmSize != nil {
+		r.Container.Resources.ShmSize = types.Int64Value(*resp.Container.Resources.ShmSize)
+	} else {
+		r.Container.Resources.ShmSize = types.Int64Null()
+	}
 	r.CountryCodes = nil
 	for _, v := range resp.CountryCodes {
 		r.CountryCodes = append(r.CountryCodes, types.StringValue(string(v)))

--- a/internal/provider/type_container_resource_requirements.go
+++ b/internal/provider/type_container_resource_requirements.go
@@ -9,4 +9,5 @@ type ContainerResourceRequirements struct {
 	GpuClass   types.String   `tfsdk:"gpu_class"`
 	GpuClasses []types.String `tfsdk:"gpu_classes"`
 	Memory     types.Int64    `tfsdk:"memory"`
+	ShmSize    types.Int64    `tfsdk:"shm_size"`
 }

--- a/internal/sdk/pkg/models/shared/containerresourcerequirements.go
+++ b/internal/sdk/pkg/models/shared/containerresourcerequirements.go
@@ -9,6 +9,7 @@ type ContainerResourceRequirements struct {
 	GpuClass   *string  `json:"gpu_class,omitempty"`
 	GpuClasses []string `json:"gpu_classes,omitempty"`
 	Memory     int64    `json:"memory"`
+	ShmSize    *int64   `json:"shm_size,omitempty"`
 }
 
 func (o *ContainerResourceRequirements) GetCPU() int64 {
@@ -37,4 +38,11 @@ func (o *ContainerResourceRequirements) GetMemory() int64 {
 		return 0
 	}
 	return o.Memory
+}
+
+func (o *ContainerResourceRequirements) GetShmSize() *int64 {
+	if o == nil {
+		return nil
+	}
+	return o.ShmSize
 }


### PR DESCRIPTION
Adds the shm_size field to ContainerResourceRequirements across all layers:
- SDK struct: ShmSize *int64 with JSON tag and getter
- Terraform model: ShmSize types.Int64
- Schema: Optional/Computed attribute with default 64MB, RequiresReplace
- Create mapping: nil-safe pointer assignment
- Read mapping: nil-safe Int64Value/Int64Null assignment

shm_size is a create-time-only attribute (RequiresReplace) since the REST API's UpdateContainerGroup does not carry resource fields. Changing shm_size forces destroy-and-recreate of the container group.